### PR TITLE
Coerce output from date("Y") and date("W") to int

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -37,8 +37,8 @@ if (is_null(pg_fetch_array($result)[0])) {
 }
 
 // Get query parameters to pass on to calendar
-$year = is_null($_GET["year"]) ? date("Y") : intval($_GET["year"]);
-$week = is_null($_GET["week"]) ? date("W") : intval($_GET["week"]);
+$year = is_null($_GET["year"]) ? intval(date("Y")) : intval($_GET["year"]);
+$week = is_null($_GET["week"]) ? intval(date("W")) : intval($_GET["week"]);
 $weeks = getWeeksWithDatesInYear($year);
 $weeks[$week]["selected"] = true;
 $monthLabel = getMonthLabel($year, $week);


### PR DESCRIPTION
The output from date("W") returns a two-digit number as a string-type.
This caused the line
```php
$weeks[$week]["selected"] = true;
```
to fail, mangling the whole index page.